### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ project(dense_hash_map_tests)
 option(ENABLE_ASAN "Enable ASAN during the tests" OFF)
 option(ENABLE_UBASAN "Enable UBASAN during the tests" OFF)
 
-add_executable(dense_hash_map_tests src/dense_hash_map_tests)
+add_executable(dense_hash_map_tests src/dense_hash_map_tests.cpp)
 target_link_libraries(dense_hash_map_tests Catch2::Catch2)
 target_link_libraries(dense_hash_map_tests dense_hash_map)
 


### PR DESCRIPTION
https://cmake.org/cmake/help/git-stage/policy/CMP0115.html
```
Starting in CMake 3.20, CMake prefers all source files to have their extensions explicitly listed:

add_executable(exe main.c)
The OLD behavior for this policy is to implicitly append known extensions to source files if they can't be found. The NEW behavior of this policy is to not append known extensions and require them to be explicit.
```